### PR TITLE
Support MongoDB 3.4 and 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,10 @@ matrix:
 
 env:
   matrix:
-    - MONGODB=3.2.3 CONFIG="--config /tmp/mongodb-wiredtiger.conf"
-    - MONGODB=3.2.3 CONFIG="--config /tmp/mongodb-mmapv1.conf"
+    - MONGODB=3.2.18 CONFIG="--config /tmp/mongodb-wiredtiger.conf"
+    - MONGODB=3.2.18 CONFIG="--config /tmp/mongodb-mmapv1.conf"
+    - MONGODB=3.4.10 CONFIG="--config /tmp/mongodb-wiredtiger.conf"
+    - MONGODB=3.6.1 CONFIG="--config /tmp/mongodb-wiredtiger.conf"
 
 before_script:
   - cp spec/config/* /tmp/

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ gemfile:
   - spec/gemfile/mongoid5.gemfile
 
 matrix:
+  fast_finish: true
   allow_failures:
     - rvm: rbx
     - rvm: jruby

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 
+#### 0.3.0
+
+* Replace `$pushAll` with `$push + $each`.
+* Aggregate methods (`max`, `sum`, etc) must use cursor in MongoDB 3.6+.
+* Config `safe: true` should send WriteConcern: Acknowledged `w: 1` to database (and not `safe: true`).
+
 #### 0.2.5
 
 * Improvements to `:touch` callback support on `:embedded_in`.

--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ If you would only like some of the patches, please copy and paste the code to yo
 
 | File | Description | 3 | 4 | 5 |
 | --- | --- | --- | --- | --- |
-| `atomic.rb` | Backport syntax change of atomic query methods. | ● | ○ | ○ |
+| `aggregate_cursor.rb` | Aggregate methods (`max`, `sum`, etc) must use cursor in MongoDB 3.6+ | ● | ○ | ○ |
+| `atomic.rb` | Backport syntax change of atomic query methods. Replace `$pushAll` with `$push + $each`. | ● | ○ | ○ |
 | `big_decimal.rb` | Fixes buggy BigDecimal behavior. | ● | ● | ● |
 | `db_commands.rb` | Use MongoDB 3.0+ command syntax; required for WiredTiger. | ● | ● | ○ |
 | `instrument.rb` | Backport instrumentation change to Moped 1. | ● | ○ | ○ |
@@ -40,6 +41,7 @@ If you would only like some of the patches, please copy and paste the code to yo
 | `embedded_touch.rb` (1) | Backport [Issue #3310](https://github.com/mongodb/mongoid/commit/a94c2f43573e58f973913c881ad9d11d62bf857c) from Mongoid 4 to add `:touch` option to `embedded_in`. | ● | ○ | ○ |
 | `embedded_touch.rb` (2) | Backport [PR #4392](https://github.com/mongodb/mongoid/pull/4392) from Mongoid 6 to fix an infinite loop issue related to `:touch` callbacks. | ● | ● | ● |
 | `index_options.rb` | Backport latest index valid index options from Mongoid 6. | ● | ● | ○ |
+| `write_concern.rb` | Config `safe: true` should send WriteConcern: Acknowledged `w: 1` to database (and not `safe: true`). | ● | ○ | ○ |
 
 ### License
 

--- a/lib/mongoid_monkey.rb
+++ b/lib/mongoid_monkey.rb
@@ -1,5 +1,6 @@
 require 'version'
 
+require 'patches/aggregate_cursor'
 require 'patches/atomic'
 require 'patches/big_decimal'
 require 'patches/db_commands'
@@ -8,3 +9,4 @@ require 'patches/instrument'
 require 'patches/reorder'
 require 'patches/only_pluck_localized'
 require 'patches/embedded_touch'
+require 'patches/write_concern'

--- a/lib/patches/aggregate_cursor.rb
+++ b/lib/patches/aggregate_cursor.rb
@@ -1,0 +1,16 @@
+# Use cursor for aggregation methods in Mongoid 3 in order to support MongoDB 3.6+
+
+if Mongoid::VERSION =~ /\A3\./
+
+  module Moped
+    class Collection
+      def aggregate(*pipeline)
+        pipeline.flatten!
+        command = { aggregate: name.to_s, pipeline: pipeline, cursor: {} }
+        result = database.session.command(command)['cursor']
+        result = result['firstBatch'] if result
+        result
+      end
+    end
+  end
+end

--- a/lib/patches/write_concern.rb
+++ b/lib/patches/write_concern.rb
@@ -2,7 +2,7 @@
 
 if Mongoid::VERSION =~ /\A3\./
 
-  module TrueClass
+  class TrueClass
     def __safe_options__
       { w: 1 }
     end

--- a/lib/patches/write_concern.rb
+++ b/lib/patches/write_concern.rb
@@ -1,0 +1,10 @@
+# Safe mode should set WriteConcern: Acknowledged in order to support MongoDB 3.4+
+
+if Mongoid::VERSION =~ /\A3\./
+
+  module TrueClass
+    def __safe_options__
+      { w: 1 }
+    end
+  end
+end

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,3 +1,3 @@
 module MongoidMonkey
-  VERSION = '0.2.5'
+  VERSION = '0.3.0'
 end

--- a/spec/app/models/address.rb
+++ b/spec/app/models/address.rb
@@ -21,4 +21,5 @@ class Address
   field :name, localize: true
 
   embedded_in :addressable, polymorphic: true
+  embeds_many :locations, validate: false
 end

--- a/spec/app/models/album.rb
+++ b/spec/app/models/album.rb
@@ -1,0 +1,14 @@
+class Album
+  include Mongoid::Document
+
+  belongs_to :artist
+  before_destroy :set_parent_name
+
+  attr_accessor :before_add_called
+
+  private
+
+  def set_parent_name
+    artist.name = "destroyed"
+  end
+end

--- a/spec/app/models/animal.rb
+++ b/spec/app/models/animal.rb
@@ -1,0 +1,25 @@
+class Animal
+  include Mongoid::Document
+
+  field :_id, type: String, default: ->{ name.try(:parameterize) }
+
+  field :name
+  field :height, type: Integer
+  field :weight, type: Integer
+  field :tags, type: Array
+
+  embedded_in :person
+  embedded_in :circus
+
+  validates_format_of :name, without: /\$\$\$/
+
+  accepts_nested_attributes_for :person
+
+  def tag_list
+    tags.join(", ")
+  end
+
+  def tag_list=(_tag_list)
+    self.tags = _tag_list.split(",").map(&:strip)
+  end
+end

--- a/spec/app/models/appointment.rb
+++ b/spec/app/models/appointment.rb
@@ -1,0 +1,7 @@
+class Appointment
+  include Mongoid::Document
+  field :active, type: Boolean, default: true
+  field :timed, type: Boolean, default: true
+  embedded_in :person
+  default_scope where(active: true)
+end

--- a/spec/app/models/artist.rb
+++ b/spec/app/models/artist.rb
@@ -1,0 +1,66 @@
+class Artist
+  include Mongoid::Document
+
+  attr_accessor :before_add_called, :after_add_called, :before_add_referenced_called, :after_add_referenced_called, :before_remove_embedded_called, :after_remove_embedded_called, :before_remove_referenced_called, :after_remove_referenced_called
+
+  field :name, type: String
+
+  embeds_many :songs, before_add: [ :before_add_song, Proc.new { |artist, song| song.before_add_called = true } ], before_remove: :before_remove_song
+  embeds_many :labels, after_add: :after_add_label, after_remove: :after_remove_label
+  has_many :albums, dependent: :destroy, before_add: [:before_add_album, Proc.new { |artist, album| album.before_add_called = true} ], after_add: :after_add_album, before_remove: :before_remove_album, after_remove: :after_remove_album
+
+  before_create :before_create_stub
+  after_create :create_songs
+  before_save :before_save_stub
+  before_destroy :before_destroy_stub
+
+  protected
+  def before_create_stub
+    true
+  end
+
+  def before_save_stub
+    true
+  end
+
+  def before_destroy_stub
+    true
+  end
+
+  def create_songs
+    2.times { |n| songs.create!(title: "#{n}") }
+  end
+
+  def before_add_song(song)
+    @before_add_called = true
+  end
+
+  def after_add_label(label)
+    @after_add_called = true
+  end
+
+  def before_add_album(album)
+    @before_add_referenced_called = true
+  end
+
+  def after_add_album(album)
+    @after_add_referenced_called = true
+  end
+
+  def before_remove_song(song)
+    @before_remove_embedded_called = true
+  end
+
+  def after_remove_label(label)
+    @after_remove_embedded_called = true
+  end
+
+  def before_remove_album(album)
+    @before_remove_referenced_called = true
+  end
+
+  def after_remove_album(album)
+    @after_remove_referenced_called = true
+  end
+
+end

--- a/spec/app/models/circus.rb
+++ b/spec/app/models/circus.rb
@@ -1,0 +1,7 @@
+class Circus
+  include Mongoid::Document
+
+  field :name
+
+  embeds_many :animals
+end

--- a/spec/app/models/country_code.rb
+++ b/spec/app/models/country_code.rb
@@ -1,0 +1,8 @@
+class CountryCode
+  include Mongoid::Document
+
+  field :_id, type: Integer, default: ->{ code }
+
+  field :code, type: Integer
+  embedded_in :phone_number, class_name: "Phone"
+end

--- a/spec/app/models/label.rb
+++ b/spec/app/models/label.rb
@@ -1,0 +1,39 @@
+class Label
+  include Mongoid::Document
+  include Mongoid::Timestamps::Updated::Short
+
+  field :name, type: String
+  field :after_create_called, type: Boolean, default: false
+  field :after_save_called, type: Boolean, default: false
+  field :after_update_called, type: Boolean, default: false
+  field :after_validation_called, type: Boolean, default: false
+
+  embedded_in :artist
+
+  after_create :after_create_stub
+  after_save :after_save_stub
+  after_update :after_update_stub
+  after_validation :after_validation_stub
+  before_validation :cleanup
+
+  def after_create_stub
+    self.after_create_called = true
+  end
+
+  def after_save_stub
+    self.after_save_called = true
+  end
+
+  def after_update_stub
+    self.after_update_called = true
+  end
+
+  def after_validation_stub
+    self.after_validation_called = true
+  end
+
+  private
+  def cleanup
+    self.name = self.name.downcase.capitalize
+  end
+end

--- a/spec/app/models/location.rb
+++ b/spec/app/models/location.rb
@@ -1,0 +1,8 @@
+class Location
+  include Mongoid::Document
+  field :name
+  field :info, type: Hash
+  field :occupants, type: Array
+  field :number, type: Integer
+  embedded_in :address
+end

--- a/spec/app/models/page.rb
+++ b/spec/app/models/page.rb
@@ -1,6 +1,7 @@
 class Page
   include Mongoid::Document
-
+  embedded_in :quiz
+  embeds_many :page_questions
   embedded_in :book, touch: true
   field :content, :type => String
 end

--- a/spec/app/models/page_question.rb
+++ b/spec/app/models/page_question.rb
@@ -1,0 +1,4 @@
+class PageQuestion
+  include Mongoid::Document
+  embedded_in :page
+end

--- a/spec/app/models/person.rb
+++ b/spec/app/models/person.rb
@@ -39,6 +39,11 @@ class Person
   field :range, type: Range
 
   embeds_many :addresses, as: :addressable, validate: false
+  embeds_many :videos, order: [[ :title, :asc ]], validate: false
+  embeds_many :appointments, validate: false
+  embeds_many :symptoms, validate: false
+  embeds_many :phone_numbers, class_name: "Phone", validate: false
+  embeds_many :phones, store_as: :mobile_phones, validate: false
   embeds_one :name, as: :namable, validate: false do
     def extension
       "Testing"

--- a/spec/app/models/phone.rb
+++ b/spec/app/models/phone.rb
@@ -1,0 +1,11 @@
+class Phone
+  include Mongoid::Document
+
+  attr_accessor :number_in_observer
+
+  field :_id, type: String, default: ->{ number }
+
+  field :number
+  embeds_one :country_code
+  embedded_in :person
+end

--- a/spec/app/models/quiz.rb
+++ b/spec/app/models/quiz.rb
@@ -1,0 +1,10 @@
+class Quiz
+  include Mongoid::Document
+  include Mongoid::Timestamps::Created
+  field :name, type: String
+  field :topic, type: String
+  embeds_many :pages
+
+  attr_accessible :topic, as: [ :default, :admin ]
+  attr_accessible :name, as: :default
+end

--- a/spec/app/models/role.rb
+++ b/spec/app/models/role.rb
@@ -1,0 +1,7 @@
+class Role
+  include Mongoid::Document
+  field :name, type: String
+  belongs_to :user
+  belongs_to :post
+  recursively_embeds_many
+end

--- a/spec/app/models/song.rb
+++ b/spec/app/models/song.rb
@@ -1,0 +1,8 @@
+class Song
+  include Mongoid::Document
+  field :title
+  embedded_in :artist
+
+  attr_accessor :before_add_called
+
+end

--- a/spec/app/models/symptom.rb
+++ b/spec/app/models/symptom.rb
@@ -1,0 +1,6 @@
+class Symptom
+  include Mongoid::Document
+  field :name, type: String
+  embedded_in :person
+  default_scope asc(:name)
+end

--- a/spec/app/models/user.rb
+++ b/spec/app/models/user.rb
@@ -3,4 +3,5 @@ class User
   include Mongoid::Document
   field :name
   index name: 1
+  has_one :role, validate: false
 end

--- a/spec/app/models/video.rb
+++ b/spec/app/models/video.rb
@@ -1,0 +1,17 @@
+class Video
+  include Mongoid::Document
+  field :title, type: String
+  field :year, type: Integer
+  field :release_dates, type: Set
+  field :genres, type: Array
+
+  embedded_in :person
+  belongs_to :post
+  belongs_to :game
+
+  default_scope asc(:title)
+
+  attr_accessible :title, as: [ :default, :admin ]
+  attr_accessible :year, as: [ :default ]
+  attr_accessible :person_attributes, as: [ :default ]
+end

--- a/spec/unit/aggregate_cursor_spec.rb
+++ b/spec/unit/aggregate_cursor_spec.rb
@@ -1,0 +1,495 @@
+require "spec_helper"
+
+if Mongoid::VERSION =~ /\A3\./
+
+describe Mongoid::Contextual::Aggregable::Mongo do
+
+  before(:each) do
+    Mongoid.purge!
+  end
+
+  describe "#aggregates" do
+
+    context "when provided a single field" do
+
+      let!(:depeche) do
+        Band.create(name: "Depeche Mode", likes: 1000, years: 1000)
+      end
+
+      let!(:tool) do
+        Band.create(name: "Tool", likes: 500, years: 800)
+      end
+
+      let(:criteria) do
+        Band.all
+      end
+
+      let(:context) do
+        Mongoid::Contextual::Mongo.new(criteria)
+      end
+
+      context "when aggregating on a field that exists" do
+
+        context "when aggregating on an aliased field" do
+
+          let(:aggregates) do
+            context.aggregates(:years)
+          end
+
+          it "returns an avg" do
+            aggregates["avg"].should eq(900)
+          end
+
+          it "returns a count" do
+            aggregates["count"].should eq(2)
+          end
+
+          it "returns a max" do
+            aggregates["max"].should eq(1000)
+          end
+
+          it "returns a min" do
+            aggregates["min"].should eq(800)
+          end
+
+          it "returns a sum" do
+            aggregates["sum"].should eq(1800)
+          end
+        end
+
+        context "when more than 1 document is emitted" do
+
+          let(:aggregates) do
+            context.aggregates(:likes)
+          end
+
+          it "returns an avg" do
+            aggregates["avg"].should eq(750)
+          end
+
+          it "returns a count" do
+            aggregates["count"].should eq(2)
+          end
+
+          it "returns a max" do
+            aggregates["max"].should eq(1000)
+          end
+
+          it "returns a min" do
+            aggregates["min"].should eq(500)
+          end
+
+          it "returns a sum" do
+            aggregates["sum"].should eq(1500)
+          end
+        end
+
+        context "when only 1 document is emitted" do
+
+          let(:criteria) do
+            Band.where(name: "Depeche Mode")
+          end
+
+          let(:aggregates) do
+            context.aggregates(:likes)
+          end
+
+          it "returns an avg" do
+            aggregates["avg"].should eq(1000)
+          end
+
+          it "returns a count" do
+            aggregates["count"].should eq(1)
+          end
+
+          it "returns a max" do
+            aggregates["max"].should eq(1000)
+          end
+
+          it "returns a min" do
+            aggregates["min"].should eq(1000)
+          end
+
+          it "returns a sum" do
+            aggregates["sum"].should eq(1000)
+          end
+        end
+
+        context "when only 1 document is emitted because of sorting, skip and limit" do
+
+          let(:criteria) do
+            Band.desc(:name).skip(1).limit(1)
+          end
+
+          let(:aggregates) do
+            context.aggregates(:likes)
+          end
+
+          it "returns an avg" do
+            expect(aggregates["avg"]).to eq(1000)
+          end
+
+          it "returns a count of documents with that field" do
+            expect(aggregates["count"]).to eq(1)
+          end
+
+          it "returns a max" do
+            expect(aggregates["max"]).to eq(1000)
+          end
+
+          it "returns a min" do
+            expect(aggregates["min"]).to eq(1000)
+          end
+
+          it "returns a sum" do
+            expect(aggregates["sum"]).to eq(1000)
+          end
+        end
+
+      end
+
+      context "when the field does not exist" do
+
+        let(:aggregates) do
+          context.aggregates(:non_existant)
+        end
+
+        it "returns an avg" do
+          aggregates["avg"].should eq(0)
+        end
+
+        it "returns a count" do
+          aggregates["count"].should eq(2)
+        end
+
+        it "returns a max" do
+          aggregates["max"].should be_nil
+        end
+
+        it "returns a min" do
+          aggregates["min"].should be_nil
+        end
+
+        it "returns a sum" do
+          aggregates["sum"].should eq(0)
+        end
+      end
+
+      context "when the field sometimes exists" do
+        let!(:oasis) do
+          Band.create(name: "Oasis", likes: 50)
+        end
+
+        let!(:radiohead) do
+          Band.create(name: "Radiohead")
+        end
+
+        context "and the field doesn't exist on the last document" do
+          let(:criteria) do
+            Band.all
+          end
+
+          let(:context) do
+            Mongoid::Contextual::Mongo.new(criteria)
+          end
+
+          let(:aggregates) do
+            context.aggregates(:likes)
+          end
+
+          it "returns a min" do
+            aggregates["min"].should eq(50)
+          end
+        end
+
+        context "and the field doesn't exist on the before-last document" do
+          let!(:u2) do
+            Band.create(name: "U2", likes: 100)
+          end
+
+          let(:criteria) do
+            Band.all
+          end
+
+          let(:context) do
+            Mongoid::Contextual::Mongo.new(criteria)
+          end
+
+          let(:aggregates) do
+            context.aggregates(:likes)
+          end
+
+          it "returns a min" do
+            aggregates["min"].should eq(50)
+          end
+        end
+      end
+
+      context "when there are no matching documents" do
+
+        let(:criteria) do
+          Band.where(name: "New Order")
+        end
+
+        let(:aggregates) do
+          context.aggregates(:non_existant)
+        end
+
+        it "returns nil" do
+          aggregates.should eq({ "count" => 0 })
+        end
+      end
+    end
+  end
+
+  describe "#avg" do
+
+    context "when provided a single field" do
+
+      context "when there are matching documents" do
+
+        let!(:depeche) do
+          Band.create(name: "Depeche Mode", likes: 1000)
+        end
+
+        let!(:tool) do
+          Band.create(name: "Tool", likes: 500)
+        end
+
+        let(:criteria) do
+          Band.all
+        end
+
+        let(:context) do
+          Mongoid::Contextual::Mongo.new(criteria)
+        end
+
+        let(:avg) do
+          context.avg(:likes)
+        end
+
+        it "returns the avg of the provided field" do
+          avg.should eq(750)
+        end
+      end
+
+      context "when no documents match" do
+
+        let!(:depeche) do
+          Band.create(name: "Depeche Mode", likes: 1000)
+        end
+
+        let(:criteria) do
+          Band.where(name: "New Order")
+        end
+
+        let(:context) do
+          Mongoid::Contextual::Mongo.new(criteria)
+        end
+
+        let(:avg) do
+          context.avg(:likes)
+        end
+
+        it "returns nil" do
+          avg.should be_nil
+        end
+      end
+    end
+  end
+
+  describe "#max" do
+
+    context "when provided a single field" do
+
+      let!(:depeche) do
+        Band.create(name: "Depeche Mode", likes: 1000)
+      end
+
+      let!(:tool) do
+        Band.create(name: "Tool", likes: 500)
+      end
+
+      let(:criteria) do
+        Band.all
+      end
+
+      let(:context) do
+        Mongoid::Contextual::Mongo.new(criteria)
+      end
+
+      context "when provided a symbol" do
+
+        let(:max) do
+          context.max(:likes)
+        end
+
+        it "returns the max of the provided field" do
+          max.should eq(1000)
+        end
+
+        context "when no documents match" do
+
+          let(:criteria) do
+            Band.where(name: "New Order")
+          end
+
+          let(:context) do
+            Mongoid::Contextual::Mongo.new(criteria)
+          end
+
+          let(:max) do
+            context.max(:likes)
+          end
+
+          it "returns nil" do
+            max.should be_nil
+          end
+        end
+      end
+
+      context "when provided a block" do
+
+        let(:max) do
+          context.max do |a, b|
+            a.likes <=> b.likes
+          end
+        end
+
+        it "returns the document with the max value for the field" do
+          max.should eq(depeche)
+        end
+      end
+    end
+  end
+
+  describe "#min" do
+
+    context "when provided a single field" do
+
+      let!(:depeche) do
+        Band.create(name: "Depeche Mode", likes: 1000)
+      end
+
+      let!(:tool) do
+        Band.create(name: "Tool", likes: 500)
+      end
+
+      let(:criteria) do
+        Band.all
+      end
+
+      let(:context) do
+        Mongoid::Contextual::Mongo.new(criteria)
+      end
+
+      context "when provided a symbol" do
+
+        let(:min) do
+          context.min(:likes)
+        end
+
+        it "returns the min of the provided field" do
+          min.should eq(500)
+        end
+
+        context "when no documents match" do
+
+          let(:criteria) do
+            Band.where(name: "New Order")
+          end
+
+          let(:context) do
+            Mongoid::Contextual::Mongo.new(criteria)
+          end
+
+          let(:min) do
+            context.min(:likes)
+          end
+
+          it "returns nil" do
+            min.should be_nil
+          end
+        end
+      end
+
+      context "when provided a block" do
+
+        let(:min) do
+          context.min do |a, b|
+            a.likes <=> b.likes
+          end
+        end
+
+        it "returns the document with the min value for the field" do
+          min.should eq(tool)
+        end
+      end
+    end
+  end
+
+  describe "#sum" do
+
+    context "when provided a single field" do
+
+      let!(:depeche) do
+        Band.create(name: "Depeche Mode", likes: 1000)
+      end
+
+      let!(:tool) do
+        Band.create(name: "Tool", likes: 500)
+      end
+
+      let(:criteria) do
+        Band.all
+      end
+
+      let(:context) do
+        Mongoid::Contextual::Mongo.new(criteria)
+      end
+
+      context "when provided a symbol" do
+
+        let(:sum) do
+          context.sum(:likes)
+        end
+
+        it "returns the sum of the provided field" do
+          sum.should eq(1500)
+        end
+
+        context "when no documents match" do
+
+          let(:criteria) do
+            Band.where(name: "New Order")
+          end
+
+          let(:context) do
+            Mongoid::Contextual::Mongo.new(criteria)
+          end
+
+          let(:sum) do
+            context.sum(:likes)
+          end
+
+          it "returns zero" do
+            sum.should eq(0)
+          end
+        end
+      end
+
+      context "when provided a block" do
+
+        let(:sum) do
+          context.sum(&:likes)
+        end
+
+        it "returns the sum for the provided block" do
+          sum.should eq(1500)
+        end
+      end
+    end
+  end
+end
+
+end

--- a/spec/unit/atomic/mongoid3_style/atomic/embedded_insert_spec.rb
+++ b/spec/unit/atomic/mongoid3_style/atomic/embedded_insert_spec.rb
@@ -1,0 +1,1213 @@
+require "spec_helper"
+
+if Mongoid::VERSION =~ /\A3\./
+
+describe Mongoid::Relations::Embedded::Many do
+
+  [ :<<, :push ].each do |method|
+
+    describe "##{method}" do
+
+      context "when the parent is a new record" do
+
+        let(:person) do
+          Person.new
+        end
+
+        let(:address) do
+          Address.new
+        end
+
+        let!(:added) do
+          person.addresses.send(method, address)
+        end
+
+        it "appends to the target" do
+          person.addresses.should eq([ address ])
+        end
+
+        it "sets the base on the inverse relation" do
+          address.addressable.should eq(person)
+        end
+
+        it "sets the same instance on the inverse relation" do
+          address.addressable.should eql(person)
+        end
+
+        it "does not save the new document" do
+          address.should_not be_persisted
+        end
+
+        it "sets the parent on the child" do
+          address._parent.should eq(person)
+        end
+
+        it "sets the metadata on the child" do
+          address.metadata.should_not be_nil
+        end
+
+        it "sets the index on the child" do
+          address._index.should eq(0)
+        end
+
+        it "returns the relation" do
+          added.should eq(person.addresses)
+        end
+
+        context "with a limiting default scope" do
+
+          context "when the document matches the scope" do
+
+            let(:active) do
+              Appointment.new
+            end
+
+            before do
+              person.appointments.send(method, active)
+            end
+
+            it "appends to the target" do
+              person.appointments.target.should eq([ active ])
+            end
+
+            it "appends to the _unscoped" do
+              person.appointments.send(:_unscoped).should eq([ active ])
+            end
+          end
+
+          context "when the document does not match the scope" do
+
+            let(:inactive) do
+              Appointment.new(active: false)
+            end
+
+            before do
+              person.appointments.send(method, inactive)
+            end
+
+            it "doesn't append to the target" do
+              person.appointments.target.should_not eq([ inactive ])
+            end
+
+            it "appends to the _unscoped" do
+              person.appointments.send(:_unscoped).should eq([ inactive ])
+            end
+          end
+        end
+      end
+
+      context "when the parent is not a new record" do
+
+        let(:person) do
+          Person.create
+        end
+
+        let(:address) do
+          Address.new
+        end
+
+        before do
+          person.addresses.send(method, address)
+        end
+
+        it "saves the new document" do
+          address.should be_persisted
+        end
+      end
+
+      context "when appending more than one document at once" do
+
+        let(:person) do
+          Person.create
+        end
+
+        let(:address_one) do
+          Address.new
+        end
+
+        let(:address_two) do
+          Address.new
+        end
+
+        let!(:added) do
+          person.addresses.send(method, [ address_one, address_two ])
+        end
+
+        it "saves the first document" do
+          address_one.should be_persisted
+        end
+
+        it "saves the second document" do
+          address_two.should be_persisted
+        end
+
+        it "returns the relation" do
+          added.should eq(person.addresses)
+        end
+      end
+
+      context "when the parent and child have a cyclic relation" do
+
+        context "when the parent is a new record" do
+
+          let(:parent_role) do
+            Role.new
+          end
+
+          let(:child_role) do
+            Role.new
+          end
+
+          before do
+            parent_role.child_roles.send(method, child_role)
+          end
+
+          it "appends to the target" do
+            parent_role.child_roles.should eq([ child_role ])
+          end
+
+          it "sets the base on the inverse relation" do
+            child_role.parent_role.should eq(parent_role)
+          end
+
+          it "sets the same instance on the inverse relation" do
+            child_role.parent_role.should eql(parent_role)
+          end
+
+          it "does not save the new document" do
+            child_role.should_not be_persisted
+          end
+
+          it "sets the parent on the child" do
+            child_role._parent.should eq(parent_role)
+          end
+
+          it "sets the metadata on the child" do
+            child_role.metadata.should_not be_nil
+          end
+
+          it "sets the index on the child" do
+            child_role._index.should eq(0)
+          end
+        end
+
+        context "when the parent is not a new record" do
+
+          let(:parent_role) do
+            Role.create(name: "CEO")
+          end
+
+          let(:child_role) do
+            Role.new(name: "COO")
+          end
+
+          before do
+            parent_role.child_roles.send(method, child_role)
+          end
+
+          it "saves the new document" do
+            child_role.should be_persisted
+          end
+        end
+      end
+    end
+  end
+
+  describe "#concat" do
+
+    context "when the parent is a new record" do
+
+      let(:person) do
+        Person.new
+      end
+
+      let(:address) do
+        Address.new
+      end
+
+      before do
+        person.addresses.concat([ address ])
+      end
+
+      it "appends to the target" do
+        person.addresses.should eq([ address ])
+      end
+
+      it "appends to the unscoped" do
+        person.addresses.send(:_unscoped).should eq([ address ])
+      end
+
+      it "sets the base on the inverse relation" do
+        address.addressable.should eq(person)
+      end
+
+      it "sets the same instance on the inverse relation" do
+        address.addressable.should eql(person)
+      end
+
+      it "does not save the new document" do
+        address.should_not be_persisted
+      end
+
+      it "sets the parent on the child" do
+        address._parent.should eq(person)
+      end
+
+      it "sets the metadata on the child" do
+        address.metadata.should_not be_nil
+      end
+
+      it "sets the index on the child" do
+        address._index.should eq(0)
+      end
+    end
+
+    context "when the parent is not a new record" do
+
+      let(:person) do
+        Person.create
+      end
+
+      let(:address) do
+        Address.new
+      end
+
+      before do
+        person.addresses.concat([ address ])
+      end
+
+      it "saves the new document" do
+        address.should be_persisted
+      end
+    end
+
+    context "when concatenating an empty array" do
+
+      let(:person) do
+        Person.create
+      end
+
+      before do
+        person.addresses.should_not_receive(:batch_insert)
+        person.addresses.concat([])
+      end
+
+      it "doesn't update the target" do
+        person.addresses.should be_empty
+      end
+    end
+
+    context "when appending more than one document at once" do
+
+      let(:person) do
+        Person.create
+      end
+
+      let(:address_one) do
+        Address.new
+      end
+
+      let(:address_two) do
+        Address.new
+      end
+
+      before do
+        person.addresses.concat([ address_one, address_two ])
+      end
+
+      it "saves the first document" do
+        address_one.should be_persisted
+      end
+
+      it "saves the second document" do
+        address_two.should be_persisted
+      end
+    end
+
+    context "when the parent and child have a cyclic relation" do
+
+      context "when the parent is a new record" do
+
+        let(:parent_role) do
+          Role.new
+        end
+
+        let(:child_role) do
+          Role.new
+        end
+
+        before do
+          parent_role.child_roles.concat([ child_role ])
+        end
+
+        it "appends to the target" do
+          parent_role.child_roles.should eq([ child_role ])
+        end
+
+        it "sets the base on the inverse relation" do
+          child_role.parent_role.should eq(parent_role)
+        end
+
+        it "sets the same instance on the inverse relation" do
+          child_role.parent_role.should eql(parent_role)
+        end
+
+        it "does not save the new document" do
+          child_role.should_not be_persisted
+        end
+
+        it "sets the parent on the child" do
+          child_role._parent.should eq(parent_role)
+        end
+
+        it "sets the metadata on the child" do
+          child_role.metadata.should_not be_nil
+        end
+
+        it "sets the index on the child" do
+          child_role._index.should eq(0)
+        end
+      end
+
+      context "when the parent is not a new record" do
+
+        let(:parent_role) do
+          Role.create(name: "CEO")
+        end
+
+        let(:child_role) do
+          Role.new(name: "COO")
+        end
+
+        before do
+          parent_role.child_roles.concat([ child_role ])
+        end
+
+        it "saves the new document" do
+          child_role.should be_persisted
+        end
+      end
+    end
+  end
+
+  describe "#count" do
+
+    let(:person) do
+      Person.create
+    end
+
+    before do
+      person.addresses.create(street: "Upper")
+      person.addresses.build(street: "Bond")
+    end
+
+    it "returns the number of persisted documents" do
+      person.addresses.count.should eq(1)
+    end
+  end
+
+  describe "#max" do
+
+    let(:person) do
+      Person.new
+    end
+
+    let(:address_one) do
+      Address.new(number: 5)
+    end
+
+    let(:address_two) do
+      Address.new(number: 10)
+    end
+
+    before do
+      person.addresses.push(address_one, address_two)
+    end
+
+    let(:max) do
+      person.addresses.max do |a,b|
+        a.number <=> b.number
+      end
+    end
+
+    it "returns the document with the max value of the supplied field" do
+      max.should eq(address_two)
+    end
+  end
+
+  describe "#max_by" do
+
+    let(:person) do
+      Person.new
+    end
+
+    let(:address_one) do
+      Address.new(number: 5)
+    end
+
+    let(:address_two) do
+      Address.new(number: 10)
+    end
+
+    before do
+      person.addresses.push(address_one, address_two)
+    end
+
+    let(:max) do
+      person.addresses.max_by(&:number)
+    end
+
+    it "returns the document with the max value of the supplied field" do
+      max.should eq(address_two)
+    end
+  end
+
+  describe "#min" do
+
+    let(:person) do
+      Person.new
+    end
+
+    let(:address_one) do
+      Address.new(number: 5)
+    end
+
+    let(:address_two) do
+      Address.new(number: 10)
+    end
+
+    before do
+      person.addresses.push(address_one, address_two)
+    end
+
+    let(:min) do
+      person.addresses.min do |a,b|
+        a.number <=> b.number
+      end
+    end
+
+    it "returns the min value of the supplied field" do
+      min.should eq(address_one)
+    end
+  end
+
+  describe "#min_by" do
+
+    let(:person) do
+      Person.new
+    end
+
+    let(:address_one) do
+      Address.new(number: 5)
+    end
+
+    let(:address_two) do
+      Address.new(number: 10)
+    end
+
+    before do
+      person.addresses.push(address_one, address_two)
+    end
+
+    let(:min) do
+      person.addresses.min_by(&:number)
+    end
+
+    it "returns the min value of the supplied field" do
+      min.should eq(address_one)
+    end
+  end
+
+  context "when deeply embedding documents" do
+
+    context "when updating the bottom level" do
+
+      let!(:person) do
+        Person.create
+      end
+
+      let!(:address) do
+        person.addresses.create(street: "Joachimstr")
+      end
+
+      let!(:location) do
+        address.locations.create(name: "work")
+      end
+
+      context "when updating with a hash" do
+
+        before do
+          address.update_attributes(locations: [{ name: "home" }])
+        end
+
+        it "updates the attributes" do
+          address.locations.first.name.should eq("home")
+        end
+
+        it "overwrites the existing documents" do
+          address.locations.count.should eq(1)
+        end
+
+        it "persists the changes" do
+          address.reload.locations.count.should eq(1)
+        end
+      end
+    end
+
+    context "when building the tree through hashes" do
+
+      let(:circus) do
+        Circus.new(hash)
+      end
+
+      let(:animal) do
+        circus.animals.first
+      end
+
+      let(:animal_name) do
+        "Lion"
+      end
+
+      let(:tag_list) do
+        "tigers, bears, oh my"
+      end
+
+      context "when the hash uses stringified keys" do
+
+        let(:hash) do
+          { 'animals' => [{ 'name' => animal_name, 'tag_list' => tag_list }] }
+        end
+
+        it "sets up the hierarchy" do
+          animal.circus.should eq(circus)
+        end
+
+        it "assigns the attributes" do
+          animal.name.should eq(animal_name)
+        end
+
+        it "uses custom writer methods" do
+          animal.tag_list.should eq(tag_list)
+        end
+      end
+
+      context "when the hash uses symbolized keys" do
+
+        let(:hash) do
+          { animals: [{ name: animal_name, tag_list: tag_list }] }
+        end
+
+        it "sets up the hierarchy" do
+          animal.circus.should eq(circus)
+        end
+
+        it "assigns the attributes" do
+          animal.name.should eq(animal_name)
+        end
+
+        it "uses custom writer methods" do
+          animal.tag_list.should eq(tag_list)
+        end
+      end
+    end
+
+    context "when building the tree through pushes" do
+
+      let(:quiz) do
+        Quiz.new
+      end
+
+      let(:page) do
+        Page.new
+      end
+
+      let(:page_question) do
+        PageQuestion.new
+      end
+
+      before do
+        quiz.pages << page
+        page.page_questions << page_question
+      end
+
+      let(:question) do
+        quiz.pages.first.page_questions.first
+      end
+
+      it "sets up the hierarchy" do
+        question.should eq(page_question)
+      end
+    end
+
+    context "when building the tree through builds" do
+
+      let!(:quiz) do
+        Quiz.new
+      end
+
+      let!(:page) do
+        quiz.pages.build
+      end
+
+      let!(:page_question) do
+        page.page_questions.build
+      end
+
+      let(:question) do
+        quiz.pages.first.page_questions.first
+      end
+
+      it "sets up the hierarchy" do
+        question.should eq(page_question)
+      end
+    end
+
+    context "when creating a persisted tree" do
+
+      let(:quiz) do
+        Quiz.create
+      end
+
+      let(:page) do
+        Page.new
+      end
+
+      let(:page_question) do
+        PageQuestion.new
+      end
+
+      let(:question) do
+        quiz.pages.first.page_questions.first
+      end
+
+      before do
+        quiz.pages << page
+        page.page_questions << page_question
+      end
+
+      it "sets up the hierarchy" do
+        question.should eq(page_question)
+      end
+
+      context "when reloading" do
+
+        let(:from_db) do
+          quiz.reload
+        end
+
+        let(:reloaded_question) do
+          from_db.pages.first.page_questions.first
+        end
+
+        it "reloads the entire tree" do
+          reloaded_question.should eq(question)
+        end
+      end
+    end
+  end
+
+  context "when deeply nesting documents" do
+
+    context "when all documents are new" do
+
+      let(:person) do
+        Person.new
+      end
+
+      let(:address) do
+        Address.new
+      end
+
+      let(:location) do
+        Location.new
+      end
+
+      before do
+        address.locations << location
+        person.addresses << address
+      end
+
+      context "when saving the root" do
+
+        before do
+          person.save
+        end
+
+        it "persists the first level document" do
+          person.reload.addresses.first.should eq(address)
+        end
+
+        it "persists the second level document" do
+          person.reload.addresses[0].locations.should eq([ location ])
+        end
+      end
+    end
+  end
+
+  context "when attempting nil pushes and substitutes" do
+
+    let(:home_phone) do
+      Phone.new(number: "555-555-5555")
+    end
+
+    let(:office_phone) do
+      Phone.new(number: "666-666-6666")
+    end
+
+    describe "replacing the entire embedded list" do
+
+      context "when an embeds many relationship contains a nil as the first item" do
+
+        let(:person) do
+          Person.create!
+        end
+
+        let(:phone_list) do
+          [nil, home_phone, office_phone]
+        end
+
+        before do
+          person.phone_numbers = phone_list
+          person.save!
+        end
+
+        it "ignores the nil and persist the remaining items" do
+          reloaded = Person.find(person.id)
+          reloaded.phone_numbers.should eq([ home_phone, office_phone ])
+        end
+      end
+
+      context "when an embeds many relationship contains a nil in the middle of the list" do
+
+        let(:person) do
+          Person.create!
+        end
+
+        let(:phone_list) do
+          [home_phone, nil, office_phone]
+        end
+
+        before do
+          person.phone_numbers = phone_list
+          person.save!
+        end
+
+        it "ignores the nil and persist the remaining items" do
+          reloaded = Person.find(person.id)
+          reloaded.phone_numbers.should eq([ home_phone, office_phone ])
+        end
+      end
+
+      context "when an embeds many relationship contains a nil at the end of the list" do
+
+        let(:person) do
+          Person.create!
+        end
+
+        let(:phone_list) do
+          [home_phone, office_phone, nil]
+        end
+
+        before do
+          person.phone_numbers = phone_list
+          person.save!
+        end
+
+        it "ignores the nil and persist the remaining items" do
+          reloaded = Person.find(person.id)
+          reloaded.phone_numbers.should eq([ home_phone, office_phone ])
+        end
+      end
+    end
+
+    describe "appending to the embedded list" do
+
+      context "when appending a nil to the first position in an embedded list" do
+
+        let(:person) do
+          Person.create! phone_numbers: []
+        end
+
+        before do
+          person.phone_numbers << nil
+          person.phone_numbers << home_phone
+          person.phone_numbers << office_phone
+          person.save!
+        end
+
+        it "ignores the nil and persist the remaining items" do
+          reloaded = Person.find(person.id)
+          reloaded.phone_numbers.should eq(person.phone_numbers)
+        end
+      end
+
+      context "when appending a nil into the middle of an embedded list" do
+
+        let(:person) do
+          Person.create! phone_numbers: []
+        end
+
+        before do
+          person.phone_numbers << home_phone
+          person.phone_numbers << nil
+          person.phone_numbers << office_phone
+          person.save!
+        end
+
+        it "ignores the nil and persist the remaining items" do
+          reloaded = Person.find(person.id)
+          reloaded.phone_numbers.should eq(person.phone_numbers)
+        end
+      end
+
+      context "when appending a nil to the end of an embedded list" do
+
+        let(:person) do
+          Person.create! phone_numbers: []
+        end
+
+        before do
+          person.phone_numbers << home_phone
+          person.phone_numbers << office_phone
+          person.phone_numbers << nil
+          person.save!
+        end
+
+        it "ignores the nil and persist the remaining items" do
+          reloaded = Person.find(person.id)
+          reloaded.phone_numbers.should eq(person.phone_numbers)
+        end
+      end
+    end
+  end
+
+  context "when moving an embedded document from one parent to another" do
+
+    let!(:person_one) do
+      Person.create
+    end
+
+    let!(:person_two) do
+      Person.create
+    end
+
+    let!(:address) do
+      person_one.addresses.create(street: "Kudamm")
+    end
+
+    before do
+      person_two.addresses << address
+    end
+
+    it "adds the document to the new paarent" do
+      person_two.addresses.should eq([ address ])
+    end
+
+    it "sets the new parent on the document" do
+      address._parent.should eq(person_two)
+    end
+
+    context "when reloading the documents" do
+
+      before do
+        person_one.reload
+        person_two.reload
+      end
+
+      it "persists the change to the new parent" do
+        person_two.addresses.should eq([ address ])
+      end
+
+      it "keeps the address on the previous document" do
+        person_one.addresses.should eq([ address ])
+      end
+    end
+  end
+
+  context "when the relation has a default scope" do
+
+    let!(:person) do
+      Person.create
+    end
+
+    context "when the default scope is a sort" do
+
+      let(:cough) do
+        Symptom.new(name: "cough")
+      end
+
+      let(:headache) do
+        Symptom.new(name: "headache")
+      end
+
+      let(:nausea) do
+        Symptom.new(name: "nausea")
+      end
+
+      before do
+        person.symptoms.concat([ nausea, cough, headache ])
+      end
+
+      context "when accessing the relation" do
+
+        let(:symptoms) do
+          person.reload.symptoms
+        end
+
+        it "applies the default scope" do
+          symptoms.should eq([ cough, headache, nausea ])
+        end
+      end
+
+      context "when modifying the relation" do
+
+        let(:constipation) do
+          Symptom.new(name: "constipation")
+        end
+
+        before do
+          person.symptoms.push(constipation)
+        end
+
+        context "when reloading" do
+
+          let(:symptoms) do
+            person.reload.symptoms
+          end
+
+          it "applies the default scope" do
+            symptoms.should eq([ constipation, cough, headache, nausea ])
+          end
+        end
+      end
+
+      context "when unscoping the relation" do
+
+        let(:unscoped) do
+          person.reload.symptoms.unscoped
+        end
+
+        it "removes the default scope" do
+          unscoped.should eq([ nausea, cough, headache ])
+        end
+      end
+    end
+  end
+
+  context "when the embedded document has an array field" do
+
+    let!(:person) do
+      Person.create
+    end
+
+    let!(:video) do
+      person.videos.create
+    end
+
+    context "when saving the array on a persisted document" do
+
+      before do
+        video.genres = [ "horror", "scifi" ]
+        video.save
+      end
+
+      it "sets the value" do
+        video.genres.should eq([ "horror", "scifi" ])
+      end
+
+      it "persists the value" do
+        video.reload.genres.should eq([ "horror", "scifi" ])
+      end
+
+      context "when reloading the parent" do
+
+        let!(:loaded_person) do
+          Person.find(person.id)
+        end
+
+        let!(:loaded_video) do
+          loaded_person.videos.find(video.id)
+        end
+
+        context "when writing a new array value" do
+
+          before do
+            loaded_video.genres = [ "comedy" ]
+            loaded_video.save
+          end
+
+          it "sets the new value" do
+            loaded_video.genres.should eq([ "comedy" ])
+          end
+
+          it "persists the new value" do
+            loaded_video.reload.genres.should eq([ "comedy" ])
+          end
+        end
+      end
+    end
+  end
+
+  context "when adding a document" do
+
+    let(:person) do
+      Person.new
+    end
+
+    let(:address_one) do
+      Address.new(street: "hobrecht")
+    end
+
+    let(:first_add) do
+      person.addresses.push(address_one)
+    end
+
+    context "when chaining a second add" do
+
+      let(:address_two) do
+        Address.new(street: "friedel")
+      end
+
+      let(:result) do
+        first_add.push(address_two)
+      end
+
+      it "adds both documents" do
+        result.should eq([ address_one, address_two ])
+      end
+    end
+  end
+
+  context "when using dot notation in a criteria" do
+
+    let(:person) do
+      Person.new
+    end
+
+    let!(:address) do
+      person.addresses.build(street: "hobrecht")
+    end
+
+    let!(:location) do
+      address.locations.build(number: 5)
+    end
+
+    let(:criteria) do
+      person.addresses.where("locations.number" => { "$gt" => 3 })
+    end
+
+    it "allows the dot notation criteria" do
+      criteria.should eq([ address ])
+    end
+  end
+
+  context "when updating multiple levels in one update" do
+
+    let!(:person) do
+      Person.create(
+          addresses: [
+              { locations: [{ name: "home" }]}
+          ]
+      )
+    end
+
+    context "when updating with hashes" do
+
+      let(:from_db) do
+        Person.find(person.id)
+      end
+
+      before do
+        from_db.update_attributes(
+            addresses: [
+                { locations: [{ name: "work" }]}
+            ]
+        )
+      end
+
+      let(:updated) do
+        person.reload.addresses.first.locations.first
+      end
+
+      it "updates the nested document" do
+        updated.name.should eq("work")
+      end
+    end
+  end
+
+  context "when pushing with a before_add callback" do
+
+    let(:artist) do
+      Artist.new
+    end
+
+    let(:song) do
+      Song.new
+    end
+
+    context "when no errors are raised" do
+
+      before do
+        artist.songs << song
+      end
+
+      it "executes the callback" do
+        artist.before_add_called.should eq true
+      end
+
+      it "executes the callback as proc" do
+        song.before_add_called.should eq true
+      end
+
+      it "adds the document to the relation" do
+        artist.songs.should eq([song])
+      end
+    end
+
+    context "with errors" do
+
+      before do
+        artist.should_receive(:before_add_song).and_raise
+      end
+
+      it "does not add the document to the relation" do
+        expect {
+          artist.songs << song
+        }.to raise_error
+        artist.songs.should be_empty
+      end
+    end
+  end
+
+  context "when pushing with an after_add callback" do
+
+    let(:artist) do
+      Artist.new
+    end
+
+    let(:label) do
+      Label.new
+    end
+
+    it "executes the callback" do
+      artist.labels << label
+      artist.after_add_called.should eq true
+    end
+
+    context "when errors are raised" do
+
+      before do
+        artist.should_receive(:after_add_label).and_raise
+      end
+
+      it "adds the document to the relation" do
+        expect {
+          artist.labels << label
+        }.to raise_error
+        artist.labels.should eq([ label ])
+      end
+    end
+  end
+end
+
+end

--- a/spec/unit/only_pluck_localized_spec.rb
+++ b/spec/unit/only_pluck_localized_spec.rb
@@ -80,7 +80,7 @@ if defined?(Moped) && Moped::VERSION =~ /\A3\./
 
           it "only limits the fields on the correct criteria" do
             criteria.each do |band|
-              Band.new.active.should be_true
+              Band.new.active.should eq true
             end
           end
         end
@@ -94,7 +94,7 @@ if defined?(Moped) && Moped::VERSION =~ /\A3\./
           it "only limits the fields on the correct criteria" do
             criteria.each do |band|
               Band.all.each do |b|
-                b.active.should be_true
+                b.active.should eq true
               end
             end
           end

--- a/spec/unit/write_concern_spec.rb
+++ b/spec/unit/write_concern_spec.rb
@@ -1,0 +1,29 @@
+require "spec_helper"
+
+if Mongoid::VERSION =~ /\A3\./
+
+  describe Moped::Query do
+
+    let(:session) do
+      Moped::Session.new([ "127.0.0.1:27017" ], database: "moped_test")
+    end
+
+    it "safe mode should set w: 1" do
+      session.with(safe: true) do |session|
+        expect(session.safety).to eq(w: 1)
+      end
+    end
+
+    it "allow w: majority" do
+      session.with(safe: {w: 'majority'}) do |session|
+        expect(session.safety).to eq(w: 'majority')
+      end
+    end
+
+    it "supports non safe mode" do
+      session.with(safe: false) do |session|
+        expect(session.safety).to eq false
+      end
+    end
+  end
+end


### PR DESCRIPTION
* Replace `$pushAll` with `$push + $each`.
* Aggregate methods (`max`, `sum`, etc) must use cursor in MongoDB 3.6+.
* Config `safe: true` should set WriteConcern: Acknowledged `w: 1` option and not `safe: true`.