### PR TITLE
Remove deprecation message for ruby 2.5+

### DIFF
--- a/lib/patches/big_decimal.rb
+++ b/lib/patches/big_decimal.rb
@@ -15,7 +15,7 @@ if Mongoid::VERSION =~ /\A[345]\./
           module ClassMethods
 
             def demongoize(object)
-              object && object.numeric? ? ::BigDecimal.new(object.to_s) : nil
+              object && object.numeric? ? BigDecimal(object.to_s) : nil
             end
 
             def mongoize(object)


### PR DESCRIPTION
~- [ ] Upgrade version, dependencies~
- [x] Remove BigDecimal deprecation